### PR TITLE
Don't make plugins global

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 // Load Gulp
 var gulp    = require('gulp'),
     gutil   = require('gulp-util');
-    plugins = require('gulp-load-plugins')();
+var plugins = require('gulp-load-plugins')();
 
 // Start Watching: Run "gulp"
 gulp.task('default', ['watch']);


### PR DESCRIPTION
`plugins` should be a var rather than a global thing. 

For reference, the [official documentation](https://www.npmjs.com/package/gulp-load-plugins) also gives the following as example: 

``` javascript
var plugins = require('gulp-load-plugins')();
```
