### PR TITLE
Running a local server using gulp-live-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A super clean and easy to use starter kit for using Gulp and Less. This should h
 ## Features
 
 ### LESS / CSS Stuff
+
 - Watches for Less changes on save
 - Checks for Less errors and outputs them without you having to rerun Gulp
 - Autoprefixes for legacy browsers
@@ -19,20 +20,36 @@ A super clean and easy to use starter kit for using Gulp and Less. This should h
 - Includes Less Bootstrap
 
 ### Javascript Stuff
+
 - Automatically compiles all jQuery libraries into one big file JS file
 - Lints custom scripts for errors
 - Combines all custom scripts into one file
 
 ## How To Use
+
     $ git clone git@github.com:scotch-io/gulp-and-less-starter-kit.git
     $ cd gulp-and-less-starter-kit
     $ npm install
+    
+After, run
+
     $ gulp
     
+Or 
+
+    $ gulp server
     
+...if you need a local server. Folder **build** serving at [http://localhost:8888](http://localhost:8888)
+
+Should use [Livereload extension](http://livereload.com/extensions/). Or inject `<script src="//localhost:35729/livereload.js"></script>` into your page.
+
+When you change a LESS(or JS) file, the page will reload.
+
 ## Updates
 
 **If this isn't working**, it's probably because you need to update. Just run `npm update --save-dev`
+
+**If no command gulp found?**, you need to install it globally `npm install -g gulp` or run `npm run gulp`
 
 ### Still broken or not working?
 
@@ -49,7 +66,7 @@ gulp
 ## Quick Tips
 - Any changes in `assets/less/*` will trigger the Less to compile on save
 - All files in `assets/js/libs/*`  will be compressed to `build/jquery.plugins.min.js`
-- All files in `assets/js/*` (except for `libs`) will be compressed to scripts.min.js
+- All files in `assets/js/*` (except for `libs`) will be compressed to `build/scripts.min.js`
 
 
 #### Special Thanks

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 // Load Gulp
-var gulp    = require('gulp'),
-    gutil   = require('gulp-util'),
+var gulp = require('gulp'),
+    gutil = require('gulp-util'),
     plugins = require('gulp-load-plugins')({
         rename: {
             'gulp-live-server': 'serve'
@@ -8,36 +8,39 @@ var gulp    = require('gulp'),
     });
 
 // Start Watching: Run "gulp"
-gulp.task('default', ['serve']);
+gulp.task('default', ['watch']);
+
+// Run "gulp server"
+gulp.task('server', ['serve', 'watch']);
 
 // Minify jQuery Plugins: Run manually with: "gulp squish-jquery"
-gulp.task('squish-jquery', function() {
-  return gulp.src('assets/js/libs/**/*.js')
-    .pipe(plugins.uglify({
+gulp.task('squish-jquery', function () {
+    return gulp.src('assets/js/libs/**/*.js')
+        .pipe(plugins.uglify({
             output: {
                 'ascii_only': true
             }
         }))
-    .pipe(plugins.concat('jquery.plugins.min.js'))
-    .pipe(gulp.dest('build'));
+        .pipe(plugins.concat('jquery.plugins.min.js'))
+        .pipe(gulp.dest('build'));
 });
 
 // Minify Custom JS: Run manually with: "gulp build-js"
-gulp.task('build-js', function() {
-  return gulp.src('assets/js/*.js')
-    .pipe(plugins.jshint())
-    .pipe(plugins.jshint.reporter('jshint-stylish'))
-    .pipe(plugins.uglify({
+gulp.task('build-js', function () {
+    return gulp.src('assets/js/*.js')
+        .pipe(plugins.jshint())
+        .pipe(plugins.jshint.reporter('jshint-stylish'))
+        .pipe(plugins.uglify({
             output: {
                 'ascii_only': true
             }
         }))
-    .pipe(plugins.concat('scripts.min.js'))
-    .pipe(gulp.dest('build'));
+        .pipe(plugins.concat('scripts.min.js'))
+        .pipe(gulp.dest('build'));
 });
 
 // Less to CSS: Run manually with: "gulp build-css"
-gulp.task('build-css', function() {
+gulp.task('build-css', function () {
     return gulp.src('assets/less/*.less')
         .pipe(plugins.plumber())
         .pipe(plugins.less())
@@ -45,9 +48,8 @@ gulp.task('build-css', function() {
             gutil.log(err);
             this.emit('end');
         })
-        .pipe(plugins.autoprefixer(
-            {
-                browsers: [
+        .pipe(plugins.autoprefixer({
+            browsers: [
                     '> 1%',
                     'last 2 versions',
                     'firefox >= 4',
@@ -58,22 +60,24 @@ gulp.task('build-css', function() {
                     'IE 10',
                     'IE 11'
                 ],
-                cascade: false
-            }
-        ))
+            cascade: false
+        }))
         .pipe(plugins.cssmin())
         .pipe(gulp.dest('build')).on('error', gutil.log);
 });
 
 // Default task
-gulp.task('serve', function() {
-    var server = plugins.serve.static('build', 8888);
-    server.start();
-    
+gulp.task('watch', function () {
     gulp.watch('assets/js/libs/**/*.js', ['squish-jquery']);
     gulp.watch('assets/js/*.js', ['build-js']);
     gulp.watch('assets/less/**/*.less', ['build-css']);
-    
+});
+
+// Folder "build" serving at http://localhost:8888
+// Should use Livereload (http://livereload.com/extensions/)
+gulp.task('serve', function () {
+    var server = plugins.serve.static('build', 8888);
+    server.start();
     gulp.watch(['assets/less/**/*.less', 'assets/js/*.js', 'assets/js/libs/**/*.js'], function (file) {
         server.notify.apply(server, [file]);
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,23 @@
 // Load Gulp
 var gulp    = require('gulp'),
     gutil   = require('gulp-util'),
-    plugins = require('gulp-load-plugins')();
+    plugins = require('gulp-load-plugins')({
+        rename: {
+            'gulp-live-server': 'serve'
+        }
+    });
 
 // Start Watching: Run "gulp"
-gulp.task('default', ['watch']);
+gulp.task('default', ['serve']);
 
 // Minify jQuery Plugins: Run manually with: "gulp squish-jquery"
 gulp.task('squish-jquery', function() {
   return gulp.src('assets/js/libs/**/*.js')
-    .pipe(plugins.uglify())
+    .pipe(plugins.uglify({
+            output: {
+                'ascii_only': true
+            }
+        }))
     .pipe(plugins.concat('jquery.plugins.min.js'))
     .pipe(gulp.dest('build'));
 });
@@ -19,7 +27,11 @@ gulp.task('build-js', function() {
   return gulp.src('assets/js/*.js')
     .pipe(plugins.jshint())
     .pipe(plugins.jshint.reporter('jshint-stylish'))
-    .pipe(plugins.uglify())
+    .pipe(plugins.uglify({
+            output: {
+                'ascii_only': true
+            }
+        }))
     .pipe(plugins.concat('scripts.min.js'))
     .pipe(gulp.dest('build'));
 });
@@ -54,8 +66,15 @@ gulp.task('build-css', function() {
 });
 
 // Default task
-gulp.task('watch', function() {
+gulp.task('serve', function() {
+    var server = plugins.serve.static('build', 8888);
+    server.start();
+    
     gulp.watch('assets/js/libs/**/*.js', ['squish-jquery']);
     gulp.watch('assets/js/*.js', ['build-js']);
     gulp.watch('assets/less/**/*.less', ['build-css']);
+    
+    gulp.watch(['assets/less/**/*.less', 'assets/js/*.js', 'assets/js/libs/**/*.js'], function (file) {
+        server.notify.apply(server, [file]);
+    });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -73,10 +73,10 @@ gulp.task('watch', function () {
     gulp.watch('assets/less/**/*.less', ['build-css']);
 });
 
-// Folder "build" serving at http://localhost:8888
+// Folder "/" serving at http://localhost:8888
 // Should use Livereload (http://livereload.com/extensions/)
 gulp.task('serve', function () {
-    var server = plugins.serve.static('build', 8888);
+    var server = plugins.serve.static('/', 8888);
     server.start();
     gulp.watch(['assets/less/**/*.less', 'assets/js/*.js', 'assets/js/libs/**/*.js'], function (file) {
         server.notify.apply(server, [file]);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "Scotchy",
-  "version": "1.0.0",
+  "name": "scotchy",
+  "version": "1.0.1",
   "description": "Gulp Starter with Less",
   "main": " ",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "gulp": "gulp"
   },
   "repository": {
     "type": "git",
@@ -18,12 +19,13 @@
     "gulp-concat": "^2.4.3",
     "gulp-cssmin": "^0.1.6",
     "gulp-jshint": "^1.9.2",
-    "gulp-less": "3.0.1",
+    "gulp-less": "^3.0.1",
     "gulp-load-plugins": "^0.8.0",
     "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "^1.1.0",
     "gulp-util": "^3.0.3",
-    "jshint-stylish": "^1.0.0"
+    "jshint-stylish": "^1.0.0",
+    "gulp-live-server": "^0.0.29"
   }
 }


### PR DESCRIPTION
## Update package.json
- Add script `gulp`. Using:

```
$ npm run gulp
```

Because `gulp` command does not work for me.
- Add `gulp-live-server` to run a local webserver.
## Update gulpfile.js
- Use Uglify's `ascii_only` to avoid converting UTF-8 escapes.
- Using `gulp-live-server`, folder **build** serving at [http://localhost:8888](http://localhost:8888)
