### PR TITLE
The page will reload after the files in the build folder is changed.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ gulp.task('watch', function () {
 gulp.task('serve', function () {
     var server = plugins.serve.static('/', 8888);
     server.start();
-    gulp.watch(['assets/less/**/*.less', 'assets/js/*.js', 'assets/js/libs/**/*.js'], function (file) {
+    gulp.watch(['build/*'], function (file) {
         server.notify.apply(server, [file]);
     });
 });


### PR DESCRIPTION
Page will reload after LESS (or JS) file change is inaccurate. Because these files will be compiled, compression,... (takes a while), then update to the build folder.
